### PR TITLE
Issue 1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,13 +4,6 @@ module.exports = function(grunt) {
 
   // Project configuration.
   grunt.initConfig({
-    lint: {
-      files: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js']
-    },
-    watch: {
-      files: '<config:lint.files>',
-      tasks: 'default'
-    },
     jshint: {
       options: {
         curly: true,
@@ -26,14 +19,19 @@ module.exports = function(grunt) {
         node: true,
         es5: true
       },
-      globals: {}
-    }
+      validate: ['Gruntfile.js', 'tasks/**/*.js', 'test/**/*.js']
+    },
+    watch: {
+      files: '<config:jshint.files>',
+      tasks: 'default'
+    }                   
   });
 
   // Load local tasks.
   grunt.loadTasks('tasks');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
 
   // Default task.
-  grunt.registerTask('default', 'lint');
+  grunt.registerTask('default', 'jshint');
 
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "zipstream": "0.2"
     },
     "devDependencies": {
-        "grunt": "~0.3.17"
+        "grunt": "~0.4.0",
+        "grunt-contrib-jshit": ""
     },
     "keywords": [ "gruntplugin", "zip", "zipstream" ]
 }

--- a/tasks/zipstream.js
+++ b/tasks/zipstream.js
@@ -14,12 +14,12 @@ var zipstream = require('zipstream');
 module.exports = function(grunt) {
 
     grunt.registerMultiTask('zip', 'Create a ZIP file.', function() {
-        var dest = this.file.dest;
-        var files = grunt.file.expandFiles(this.file.src);
+        var dest = this.data.file.dest;
+        var files = grunt.file.expand({filter: "isFile"}, this.data.file.src);
         var options = this.data;
 
         var done = this.async();
-        grunt.helper('zipstream', dest, files, options, function(err, written) {
+        grunt.makeZipstream(dest, files, options, function(err, written) {
             if (!err) {
                 written = String(written);
                 grunt.log.writeln("File " + dest.cyan + " created.");
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
         });
     });
 
-    grunt.registerHelper('zipstream', function(dest, files, options, callback) {
+    grunt.makeZipstream = function(dest, files, options, callback) {
         var nowrite = grunt.option('no-write');
         if (typeof(options) === 'function') {
             callback = options;
@@ -102,6 +102,6 @@ module.exports = function(grunt) {
                 });
             }
         ], callbackOnce);
-    });
+    };
 
 };


### PR DESCRIPTION
Migrated the code to work with Grunt 0.4.0 (to be relased today) by:
- Renamed grunt.js to Gruntfile.js
- Adjusted the Gruntfile for 0.4.0 compatibility
- Adding grunt-contrib-jshint as a development dependency to make the Gruntfile in this repo work again
- Making the "zipstream" Helper a method of the exports, because Helpers have been removed.

If you have any questions, I'd be happy to help.
